### PR TITLE
Keep the value of v:count1

### DIFF
--- a/plugin/cycle.vim
+++ b/plugin/cycle.vim
@@ -111,9 +111,9 @@ function! s:Cycle(direction)
     " endif
 
     if a:direction == 1
-      exe "norm! \<C-A>"
+      exe "norm! " . v:count1 . "\<C-A>"
     else
-      exe "norm! \<C-X>"
+      exe "norm! " . v:count1 . "\<C-X>"
     endif
   else
     let [group, start, end, string] = match


### PR DESCRIPTION
In default Vim, `3<C-a>` on a number adds by `3`. However, this plugin ignores the count. This pull request fixes this issue.