### PR TITLE
Add yes/no to the global group

### DIFF
--- a/plugin/cycle.vim
+++ b/plugin/cycle.vim
@@ -17,6 +17,7 @@ let s:options['global'] = [
   \ ['if', 'unless'],
   \ ['true', 'false'],
   \ ['YES', 'NO'],
+  \ ['yes', 'no'],
   \ ['on', 'off'],
   \ ['running', 'stopped'],
   \ ['first', 'last'],


### PR DESCRIPTION
The YES/NO option does not match lowercase values.