### PR TITLE
Add way to override cycle definitions entirely from vimrc file.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,16 @@ recently will take precedence over groups defined previously. Keep this in mind
 when defining new cycle groups to make sure broad definitions are not matched
 when they are not desired.
 
+You may also clear all the hard coded pairs and work entirely with your own pairs.
+Use the following code to initialize your own variables at startup in your vimrc file:
+
+    g:cycle_override_defaults = [
+        ['global', ['true', 'false']],
+        ['ruby', ['class', 'module']],
+    ]
+
+This will initialize vim-cycle with only 2 pairs of cycles: one will be set globally
+and the other one will apply only to the ruby filetype.
 
 Todo
 ----

--- a/plugin/cycle.vim
+++ b/plugin/cycle.vim
@@ -7,64 +7,68 @@
 
 let s:options = {}
 
-let s:options['global'] = [
-  \ ['==', '!='],
-  \ ['_', '-'],
-  \ [' + ', ' - '],
-  \ ['-=', '+='],
-  \ ['&&', '||'],
-  \ ['and', 'or'],
-  \ ['if', 'unless'],
-  \ ['true', 'false'],
-  \ ['YES', 'NO'],
-  \ ['yes', 'no'],
-  \ ['on', 'off'],
-  \ ['running', 'stopped'],
-  \ ['first', 'last'],
-  \ ['else', 'else if'],
-\]
+let s:options['global'] = []
 
-" css/sass/javascript/html
-let s:options['global'] = s:options['global'] + [
-  \ ['div', 'p', 'span'],
-  \ ['max', 'min'],
-  \ ['ul', 'ol'],
-  \ ['class', 'id'],
-  \ ['px', '%', 'em'],
-  \ ['left', 'right'],
-  \ ['top', 'bottom'],
-  \ ['margin', 'padding'],
-  \ ['height', 'width'],
-  \ ['absolute', 'relative'],
-  \ ['h1', 'h2', 'h3'],
-  \ ['png', 'jpg', 'gif'],
-  \ ['linear', 'radial'],
-  \ ['horizontal', 'vertical'],
-  \ ['show', 'hide'],
-  \ ['mouseover', 'mouseout'],
-  \ ['mouseenter', 'mouseleave'],
-  \ ['add', 'remove'],
-  \ ['up', 'down'],
-  \ ['before', 'after'],
-  \ ['text', 'html'],
-  \ ['slow', 'fast'],
-  \ ['small', 'large'],
-  \ ['even', 'odd'],
-  \ ['inside', 'outside'],
-  \ ['push', 'pull'],
-\]
+if !exists("g:cycle_override_defaults")
+    let s:options['global'] = [
+      \ ['==', '!='],
+      \ ['_', '-'],
+      \ [' + ', ' - '],
+      \ ['-=', '+='],
+      \ ['&&', '||'],
+      \ ['and', 'or'],
+      \ ['if', 'unless'],
+      \ ['true', 'false'],
+      \ ['YES', 'NO'],
+      \ ['yes', 'no'],
+      \ ['on', 'off'],
+      \ ['running', 'stopped'],
+      \ ['first', 'last'],
+      \ ['else', 'else if'],
+    \]
 
-" ruby/eruby
-let s:options['global'] = s:options['global'] + [
-  \ ['include', 'require'],
-  \ ['Time', 'Date'],
-  \ ['present', 'blank'],
-  \ ['while', 'until'],
-  \ ['only', 'except'],
-  \ ['create', 'update'],
-  \ ['new', 'edit'],
-  \ ['get', 'post', 'put', 'patch']
-\]
+    " css/sass/javascript/html
+    let s:options['global'] = s:options['global'] + [
+      \ ['div', 'p', 'span'],
+      \ ['max', 'min'],
+      \ ['ul', 'ol'],
+      \ ['class', 'id'],
+      \ ['px', '%', 'em'],
+      \ ['left', 'right'],
+      \ ['top', 'bottom'],
+      \ ['margin', 'padding'],
+      \ ['height', 'width'],
+      \ ['absolute', 'relative'],
+      \ ['h1', 'h2', 'h3'],
+      \ ['png', 'jpg', 'gif'],
+      \ ['linear', 'radial'],
+      \ ['horizontal', 'vertical'],
+      \ ['show', 'hide'],
+      \ ['mouseover', 'mouseout'],
+      \ ['mouseenter', 'mouseleave'],
+      \ ['add', 'remove'],
+      \ ['up', 'down'],
+      \ ['before', 'after'],
+      \ ['text', 'html'],
+      \ ['slow', 'fast'],
+      \ ['small', 'large'],
+      \ ['even', 'odd'],
+      \ ['inside', 'outside'],
+      \ ['push', 'pull'],
+    \]
+
+    " ruby/eruby
+    let s:options['global'] = s:options['global'] + [
+      \ ['include', 'require'],
+      \ ['Time', 'Date'],
+      \ ['present', 'blank'],
+      \ ['while', 'until'],
+      \ ['only', 'except'],
+      \ ['create', 'update'],
+      \ ['new', 'edit'],
+      \ ['get', 'post', 'put', 'patch']
+    \]
+endif
 
 " Takes one or two arguments:
 "
@@ -210,16 +214,22 @@ function! s:match(...)
 endfunction
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-" language specific overrides:
-call AddCycleGroup('ruby', ['class', 'module'])
-call AddCycleGroup(['ruby', 'eruby', 'perl'], ['else', 'elsif'])
-call AddCycleGroup('python', ['else', 'elif'])
+if !exists("g:cycle_override_defaults")
+    " language specific overrides:
+    call AddCycleGroup('ruby', ['class', 'module'])
+    call AddCycleGroup(['ruby', 'eruby', 'perl'], ['else', 'elsif'])
+    call AddCycleGroup('python', ['else', 'elif'])
 
-" Swift
-call AddCycleGroup('swift', ['let', 'var'])
-call AddCycleGroup('swift', ['open', 'public', 'internal', 'fileprivate', 'private'])
-call AddCycleGroup('swift', ['class', 'struct', 'enum', 'protocol', 'extension'])
-call AddCycleGroup('swift', ['set', 'get'])
+    " Swift
+    call AddCycleGroup('swift', ['let', 'var'])
+    call AddCycleGroup('swift', ['open', 'public', 'internal', 'fileprivate', 'private'])
+    call AddCycleGroup('swift', ['class', 'struct', 'enum', 'protocol', 'extension'])
+    call AddCycleGroup('swift', ['set', 'get'])
+else
+  for group in g:cycle_override_defaults
+    call AddCycleGroup(group[0], group[1])
+  endfor
+endif
 
 nnoremap <silent> <Plug>CycleNext     :<C-U>call <SID>Cycle(1)<CR>
 nnoremap <silent> <Plug>CyclePrevious :<C-U>call <SID>Cycle(-1)<CR>


### PR DESCRIPTION
Added ability to override this plugin's defaults and can specify our own from scratch.  There are many times I do not want to use some/all of the hard coded cycle definitions.

Use by defining this in vimrc/autocmd:
 ```
   g:cycle_override_defaults = [
        ['global', ['true', 'false']],
        ['global', ['==', '!=']],
        ['global', ['-=', '+=']],
        ['global', ['&&', '||']],
        ['global', ['let', 'const']],
    ]
```